### PR TITLE
Bump xtensa-lx-rt dependency, fix ESP32C3 run command

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,11 +4,10 @@
 {%- else -%}
 [target.riscv32imc-unknown-none-elf]
 {%- endif %}
-runner = "espflash --format=direct-boot --monitor"
 {%- else -%}
 [target.xtensa-{{ mcu }}-none-elf]
-runner = "espflash --monitor"
 {%- endif %}
+runner = "espflash --monitor"
 
 [build]
 {% if mcu == "esp32c3" -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ esp32c3-hal = { package = "esp32c3-hal", git = "https://github.com/esp-rs/esp-ha
 riscv-rt = { version = "0.8", optional = true }
 {%- else -%}
 {{ mcu }}-hal = { package = "{{ mcu }}-hal", git = "https://github.com/esp-rs/esp-hal.git" }
-xtensa-lx-rt = { version = "0.9", features = ["{{ mcu }}"], optional = true }
+xtensa-lx-rt = { version = "0.11.0", features = ["{{ mcu }}"], optional = true }
 {%- endif %}
 
 [features]

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -3,6 +3,7 @@ cargo_generate_version = ">=0.10.0"
 ignore = [
     ".git",
     ".github",
+    "README.md",
 ]
 
 [placeholders.mcu]


### PR DESCRIPTION
Minor changes to the template

- bump `xtensa-lx-rt` dependency to 0.11.0
- remove "direct-boot" from the ESP32C3 run command
- ignore `README.md` since it's the read-me of the template - not the generated project
