### PR TITLE
Improve devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -36,7 +36,8 @@ RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
-    --build-target "${ESP_BOARD}"
+    --build-target "${ESP_BOARD}" \
+    && rustup component add clippy rustfmt
 
 # Activate ESP environment
 RUN echo "source /home/${CONTAINER_USER}/export-esp.sh" >> ~/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,25 +32,11 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
 
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
-    --extra-crates "ldproxy cargo-espflash" \
+    --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}"
-
-# Install web-flash and wokwi-server
-RUN curl -L https://github.com/bjoernQ/esp-web-flash-server/releases/latest/download/web-flash-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/web-flash
-RUN curl -L https://github.com/MabezDev/wokwi-server/releases/latest/download/wokwi-server-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/wokwi-server
 
 # Activate ESP environment
 RUN echo "source /home/${CONTAINER_USER}/export-esp.sh" >> ~/.bashrc

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -25,21 +25,8 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
     /home/${CONTAINER_USER}/${INSTALL_RUST_TOOLCHAIN}
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
-    --extra-crates "cargo-espflash ldproxy cargo-generate" \
+    --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}"
-# Install web-flash and wokwi-server
-RUN curl -L https://github.com/bjoernQ/esp-web-flash-server/releases/latest/download/web-flash-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/web-flash
-RUN curl -L https://github.com/MabezDev/wokwi-server/releases/latest/download/wokwi-server-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/wokwi-server

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -29,4 +29,5 @@ RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
-    --build-target "${ESP_BOARD}"
+    --build-target "${ESP_BOARD}" \
+    && rustup component add clippy rustfmt

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,8 @@ This repository offers Dev Containers supports for:
 
 If using VS Code or GitHub Codespaces, you can pull the image instead of building it
 from the Dockerfile by selecting the `image` property instead of `build` in
-`.devcontainer/devcontainer.json`
+`.devcontainer/devcontainer.json`. Further customization of the Dev Container can
+be achived, see [.devcontainer.json reference](https://code.visualstudio.com/docs/remote/devcontainerjson-reference).
 
 When using Dev Containers, some tooling to facilitate building, flashing and
 simulating in Wokwi is also added.


### PR DESCRIPTION
- Install `wokwi-server` and `web-flash` via rust installer, this will use binary packages if available
- Install `clippy` and `rustfmt` for RustAnalyzer 
- Add `.devcontainer.json` reference link in documentation