### PR TITLE
Bump xtensa-lx-rt to 0.12.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ riscv-rt = { version = "0.8", optional = true }
 {% if mcu == "esp32s2" -%}
 xtensa-atomic-emulation-trap = "0.1.0"
 {%- endif %}
-xtensa-lx-rt = { version = "0.11.0", features = ["{{ mcu }}"], optional = true }
+xtensa-lx-rt = { version = "0.12.0", features = ["{{ mcu }}"], optional = true }
 {%- endif %}
 
 [features]


### PR DESCRIPTION
Template now uses `xtensa-lx-rt` version 0.12.0