### PR TITLE
Include CI

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,66 @@
+name: Check format and compilation
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**/README.md'
+  pull_request:
+  schedule:
+    - cron: '50 7 * * *'
+
+jobs:
+  format-clippy-check:
+    name: Clippy | Fmt Checks (esp32c3)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: rustfmt, clippy
+      - name: Setup | Std
+        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
+      - name: Setup | Default to nightly
+        run: rustup default nightly
+      - name: Setup | cargo-generate
+        run: cargo install cargo-generate
+      - name: Setup | ldproxy
+        run: cargo install ldproxy
+      - name: Generate
+        run: cargo generate --git https://github.com/esp-rs/esp-template --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
+      - name: Build | Fmt Check
+        run: cd test-esp32c3; cargo fmt -- --check
+      - name: Build | Clippy
+        run: cd test-esp32c3; cargo clippy --no-deps
+  compile-check:
+    name: Build using the generated Dockerfile
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        board: ['esp32', 'esp32s2', 'esp32s3', 'esp32c3']
+    steps:
+      - name: Setup | cargo-generate
+        run: cargo install cargo-generate
+      - name: Generate
+        run: cargo generate --git https://github.com/esp-rs/esp-template --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
+      - name: Update ownership
+        run: |
+          sudo chown 1000:1000 -R test-${{ matrix.board }}
+      - uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: test-${{ matrix.board }}:latest
+          build-args: ESP_BOARD=${{ matrix.board }}
+          file: test-${{ matrix.board }}/.devcontainer/Dockerfile
+          push: false
+      - name: Run the build process with Docker
+        uses: addnab/docker-run-action@v3
+        with:
+            image: test-${{ matrix.board }}:latest
+            options: -u esp -v ${{ github.workspace }}/test-${{ matrix.board }}:/home/esp/test-${{ matrix.board }}
+            run: |
+              cd /home/esp/test-${{ matrix.board }}
+              bash -c 'source /home/esp/export-esp.sh && cargo build'
+


### PR DESCRIPTION
Add CI to run clippy, fmt check, and build the project for all the targets using the Dockerfile generated for devcontainer support.