### PR TITLE
Dockerfile clean-up and toolchain upgrade

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,7 @@ ENV LANG=C.UTF-8
 # Arguments
 ARG CONTAINER_USER=esp
 ARG CONTAINER_GROUP=esp
-ARG TOOLCHAIN_VERSION=1.61.0.0
-ARG ESP_IDF_VERSION=release/v4.4
+ARG TOOLCHAIN_VERSION=1.62.0.0
 ARG ESP_BOARD=esp32
 ARG INSTALL_RUST_TOOLCHAIN=install-rust-toolchain.sh
 
@@ -33,9 +32,7 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
     --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
-    --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
-    --esp-idf-version "${ESP_IDF_VERSION}" \
-    --minified-esp-idf "YES" \
+    --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --build-target "${ESP_BOARD}" \
     && rustup component add clippy rustfmt
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,12 @@
 {
   "name": "{{ crate_name }}",
   // Select between image and build propieties to pull or build the image.
-  // "image": "docker.io/espressif/idf-rust:{{ mcu }}_v4.4_1.61.0.0",
+  // "image": "docker.io/espressif/idf-rust:{{ mcu }}_1.62.0.0",
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
       "CONTAINER_USER": "esp",
       "CONTAINER_GROUP": "esp",
-      "ESP_IDF_VERSION": "release/v4.4",
       "ESP_BOARD": "{{ mcu }}"
     }
   },


### PR DESCRIPTION
- Dockerfile cleaunp:
  - `--clear-cache "YES"` is no longer needed as it [enabled by default](https://github.com/esp-rs/rust-build/blob/main/install-rust-toolchain.sh#L22)
  - Since [rust-build/#108](https://github.com/esp-rs/rust-build/pull/108) we no longer need to install esp-idf
- Updated toolchain version to `1.62.0.0`