### PR TITLE
Update CI to use binaries for `cargo-generate` and `ldproxy`

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -30,7 +30,10 @@ jobs:
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Setup | ldproxy
-        run: cargo install ldproxy
+        run: |
+          sudo curl -L "https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip" -o "/home/runner/.cargo/bin/ldproxy.zip"
+          unzip "/home/runner/.cargo/bin/ldproxy.zip" -d /home/runner/.cargo/bin
+          chmod u+x /home/runner/.cargo/bin/ldproxy
       - name: Generate
         run: cargo generate --git https://github.com/esp-rs/esp-template --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
       - name: Build | Fmt Check

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Setup | Default to nightly
         run: rustup default nightly
       - name: Setup | cargo-generate
-        run: cargo install cargo-generate
+        run:  |
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-v0.15.2-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
+          chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Setup | ldproxy
         run: cargo install ldproxy
       - name: Generate

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -26,7 +26,7 @@ jobs:
         run: rustup default nightly
       - name: Setup | cargo-generate
         run:  |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-v0.15.2-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Setup | ldproxy
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Install cargo-generate
         run: |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-v0.15.2-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Generate


### PR DESCRIPTION
CI `Clippy | Fmt Checks (esp32c3)` was [failing today in `cargo install cargo-generate`](https://github.com/esp-rs/esp-template/runs/7356580496?check_suite_focus=true) so I decided to update the CI:
- `cargo-generate` is now installed using the releases binaries
- `ldproxy` is now installed using the releases binaries
- Instead of having a fixed version of `cargo-generate` binary, use lastest

With those changes, this CI is a lot faster (~5 mins) 
