### PR TITLE
Avoid using hardcoded repo for PRs

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -34,9 +34,9 @@ jobs:
           chmod u+x /home/runner/.cargo/bin/ldproxy
       - name: Generate (PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: cargo generate --git https://github.com/esp-rs/esp-template --branch ${{ github.head_ref }} --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
+        run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
       - name: Generate (Push)
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name != 'pull_request' }}
         run: cargo generate --git https://github.com/esp-rs/esp-template --branch ${{ github.ref_name }} --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
       - name: Build | Fmt Check
         run: cd test-esp32c3; cargo fmt -- --check
@@ -57,9 +57,9 @@ jobs:
           chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Generate (PR)
         if: ${{ github.event_name == 'pull_request' }}
-        run: cargo generate --git https://github.com/esp-rs/esp-template --branch ${{ github.head_ref }} --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
+        run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
       - name: Generate (Push)
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name != 'pull_request' }}
         run: cargo generate --git https://github.com/esp-rs/esp-template  --branch ${{ github.ref_name }} --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
       - name: Update ownership
         run: |


### PR DESCRIPTION
- If any user would like to submit a PR from a fork of the repo, the CI should use his repo (and the propper branch) to generate the project to build
- Fix conditions to generate a project as `schedule` triggers were not generating any project,[ hence the CI was failing](https://github.com/esp-rs/esp-template/runs/7464362585?check_suite_focus=true#step:6:6)