### PR TITLE
Update xtensa-lx-rt, fix ESP32-C3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ riscv-rt = { version = "0.8", optional = true }
 {% if mcu == "esp32s2" -%}
 xtensa-atomic-emulation-trap = "0.1.0"
 {%- endif %}
-xtensa-lx-rt = { version = "0.12.0", features = ["{{ mcu }}"], optional = true }
+xtensa-lx-rt = { version = "0.13.0", features = ["{{ mcu }}"], optional = true }
 {%- endif %}
 
 [features]

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> ! {
 
     {% if mcu == "esp32c3" -%}
     rtc_cntl.set_super_wdt_enable(false);
-    rtc_cntl.set_wdt_enable(false);
+    rtc_cntl.set_wdt_global_enable(false);
     {%- else -%}
     rtc_cntl.set_wdt_global_enable(false);
     {%- endif %}


### PR DESCRIPTION
- use `xtensa-lx-rt` _0.13.0_
- fix ESP32-C3
