### PR TITLE
cargo: Add rustflag to force frame pointers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,6 +8,10 @@ runner = "espflash --monitor"
 [build]
 {% if mcu == "esp32c3" -%}
 rustflags = [
+  # Required to obtain backtraces (e.g. when using the "esp-backtrace" crate.)
+  # NOTE: May negatively impact performance of produced code
+  "-C", "force-frame-pointers",
+
   "-C", "link-arg=-Tlinkall.x",
 ]
 target = "riscv32imac-unknown-none-elf"


### PR DESCRIPTION
as required by the
[esp-backtrace](https://github.com/esp-rs/esp-backtrace) crate.