### PR TITLE
Make workflow succeed in forks, and speed it up considerably

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -3,77 +3,86 @@ name: Check format and compilation
 on:
   push:
     paths-ignore:
-      - '**/README.md'
+      - "**/README.md"
   pull_request:
   schedule:
-    - cron: '50 7 * * *'
+    - cron: "50 7 * * *"
 
 jobs:
   format-clippy-check:
     name: Clippy | Fmt Checks (esp32c3)
     runs-on: ubuntu-latest
+
     steps:
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1
         with:
+          default: true
+          components: clippy, rustfmt, rust-src
           toolchain: nightly
-          components: rustfmt, clippy
-      - name: Setup | Std
-        run: rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu
-      - name: Setup | Default to nightly
-        run: rustup default nightly
+
       - name: Setup | cargo-generate (binaries)
         id: binaries
         continue-on-error: true
         run: |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/download/v0.15.2/cargo-generate-v0.15.2-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
-      - name:  Setup | cargo-generate (cargo)
+
+      - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
-      - name: Setup | ldproxy
-        run: |
-          sudo curl -L "https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip" -o "/home/runner/.cargo/bin/ldproxy.zip"
-          unzip "/home/runner/.cargo/bin/ldproxy.zip" -d /home/runner/.cargo/bin
-          chmod u+x /home/runner/.cargo/bin/ldproxy
-      - name: Generate (PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        run: cargo generate --git https://github.com/${{ github.event.pull_request.head.repo.full_name }} --branch ${{ github.head_ref }} --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
-      - name: Generate (Push)
-        if: ${{ github.event_name != 'pull_request' }}
-        run: cargo generate --git https://github.com/esp-rs/esp-template --branch ${{ github.ref_name }} --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions/checkout@v3
+        with:
+          path: /home/runner/work/esp-template/esp-template/github-esp-template
+
+      - name: Generate
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --name test-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false
+
       - name: Build | Fmt Check
         run: cd test-esp32c3; cargo fmt -- --check
+
       - name: Build | Clippy
         run: cd test-esp32c3; cargo clippy --no-deps
+
   compile-check:
     name: Build using the generated Dockerfile
     runs-on: ubuntu-latest
+
     strategy:
       fail-fast: false
       matrix:
-        board: ['esp32', 'esp32s2', 'esp32s3', 'esp32c3']
+        board: ["esp32", "esp32s2", "esp32s3", "esp32c3"]
+
     steps:
-      - name: Install cargo-generate via binaries
+      - name: Setup | cargo-generate (binaries)
         id: binaries
         continue-on-error: true
         run: |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/download/v0.15.2/cargo-generate-v0.15.2-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
-      - name: Install cargo-generate via cargo
+
+      - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
-      - name: Generate (PR)
-        if: ${{ github.event_name == 'pull_request' }}
-        run: cargo generate --git https://github.com/${{ github.event.pull_request.head.repo.full_name }} --branch ${{ github.head_ref }} --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
-      - name: Generate (Push)
-        if: ${{ github.event_name != 'pull_request' }}
-        run: cargo generate --git https://github.com/esp-rs/esp-template  --branch ${{ github.ref_name }} --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
+
+      - uses: Swatinem/rust-cache@v1
+
+      - uses: actions/checkout@v3
+        with:
+          path: /home/runner/work/esp-template/esp-template/github-esp-template
+
+      - name: Generate
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true
+
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.board }}
+
       - uses: docker/build-push-action@v2
         with:
           context: .
@@ -81,12 +90,12 @@ jobs:
           build-args: ESP_BOARD=${{ matrix.board }}
           file: test-${{ matrix.board }}/.devcontainer/Dockerfile
           push: false
+
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
-            image: test-${{ matrix.board }}:latest
-            options: -u esp -v ${{ github.workspace }}/test-${{ matrix.board }}:/home/esp/test-${{ matrix.board }}
-            run: |
-              cd /home/esp/test-${{ matrix.board }}
-              bash -c 'source /home/esp/export-esp.sh && cargo build'
-
+          image: test-${{ matrix.board }}:latest
+          options: -u esp -v ${{ github.workspace }}/test-${{ matrix.board }}:/home/esp/test-${{ matrix.board }}
+          run: |
+            cd /home/esp/test-${{ matrix.board }}
+            bash -c 'source /home/esp/export-esp.sh && cargo build'


### PR DESCRIPTION
### Good:

- The workflow is now able to run in forks on arbitrary branches, so that you don't need to open a pull request and pray that CI passes
- The workflow now runs much faster, taking ~4 minutes compared to ~10 minutes

### Bad:

- The URL for the `cargo-generate` binary release is currently hard coded, as the most recent version _still_ does not have Linux artifacts

Closes #26 