### PR TITLE
Update xtensa-lx-rt to 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,14 +14,14 @@ license = "MIT OR Apache-2.0"
 {% if alloc -%}
 esp-alloc = { version = "0.1.0", features = ["oom-handler"] }
 {%- endif %}
-esp-backtrace = { version = "0.3.0", features = ["{{ mcu }}", "panic-handler", "print-uart"] }
+esp-backtrace = { version = "0.4.0", features = ["{{ mcu }}", "panic-handler", "print-uart"] }
 {% if mcu == "esp32c3" -%}
 riscv-rt = { version = "0.10", optional = true }
 {%- else -%}
 {% if mcu == "esp32s2" -%}
-xtensa-atomic-emulation-trap = "0.2.0"
+xtensa-atomic-emulation-trap = "0.3.0"
 {%- endif %}
-xtensa-lx-rt = { version = "0.13.0", features = ["{{ mcu }}"], optional = true }
+xtensa-lx-rt = { version = "0.14.0", features = ["{{ mcu }}"], optional = true }
 {%- endif %}
 
 [features]


### PR DESCRIPTION
Before applying these changes, both version 0.13 and version 0.14 was built when I created a new repo using this template. It resulted in link errors like these:

```text
error: linking with `xtensa-esp32-elf-gcc` failed: exit status: 1
  |
  = note: "xtensa-esp32-elf-gcc" <snip>
  = note: <snip>/xtensa-esp32-elf/bin/ld: <snip>/deps/libxtensa_lx_rt-e583d49af76632b7.rlib(xtensa_lx_rt-e583d49af76632b7.xtensa_lx_rt.eb13f165-cgu.11.rcgu.o): in function `__default_exception':
          <snip>/.cargo/registry/src/github.com-1ecc6299db9ec823/xtensa-lx-rt-0.14.0/src/exception/esp32.rs:95: multiple definition of `__default_exception'; <snip>/deps/libxtensa_lx_rt-b7c97e11631cd506.rlib(xtensa_lx_rt-b7c97e11631cd506.xtensa_lx_rt.5a35a154-cgu.1.rcgu.o):<snip>/.cargo/registry/src/github.com-1ecc6299db9ec823/xtensa-lx-rt-0.13.0/src/exception/esp32.rs:95: first defined here
<snip>
```