### PR TITLE
esp32c3: switch to riscv32imc-unknown-none-elf target

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 {%- if mcu == "esp32c3" -%}
-[target.riscv32imac-unknown-none-elf]
+[target.riscv32imc-unknown-none-elf]
 {%- else -%}
 [target.xtensa-{{ mcu }}-none-elf]
 {%- endif %}
@@ -14,7 +14,7 @@ rustflags = [
 
   "-C", "link-arg=-Tlinkall.x",
 ]
-target = "riscv32imac-unknown-none-elf"
+target = "riscv32imc-unknown-none-elf"
 {%- else -%}
 {%- if mcu == "esp32s2" -%}
 rustflags = [

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "Wokwi Debug",
       "executable":
       {%- if mcu == "esp32c3" -%}
-      "${workspaceFolder}/target/riscv32imac-unknown-none-elf/debug/{{ crate_name }}",
+      "${workspaceFolder}/target/riscv32imc-unknown-none-elf/debug/{{ crate_name }}",
       {%- else -%}
       "${workspaceFolder}/target/target.xtensa-{{ mcu }}-none-elf/debug/{{ crate_name }}",
       {%- endif %}

--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -20,7 +20,7 @@ esac
 
 export ESP_ARCH=
 {%- if mcu == "esp32c3" -%}
-riscv32imac-unknown-none-elf
+riscv32imc-unknown-none-elf
 {%- else -%}
 xtensa-{{ mcu }}-none-elf
 {%- endif %}

--- a/scripts/run-wokwi.sh
+++ b/scripts/run-wokwi.sh
@@ -28,7 +28,7 @@ fi
 
 export ESP_ARCH=
 {%- if mcu == "esp32c3" -%}
-riscv32imac-unknown-none-elf
+riscv32imc-unknown-none-elf
 {%- else -%}
 xtensa-{{ mcu }}-none-elf
 {%- endif %}


### PR DESCRIPTION
This switches the toolchain used for esp32c3 chip to `riscv32imc-unknown-none-elf`, removing the `a` extension. The chip itself does not have atomic instructions.