### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,10 @@ jobs:
           path: /home/runner/work/esp-template/esp-template/github-esp-template
       - name: Setup | Rust
         if: matrix.board == 'esp32c3'
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           target: riscv32imc-unknown-none-elf
           toolchain: nightly
-          default: true
           components: clippy, rustfmt, rust-src
       - name: Setup | Rust
         if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.board }}
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v4
         with:
           context: .
           tags: test-${{ matrix.board }}:latest


### PR DESCRIPTION
- Replaced `actions-rs/toolchain` by `dtolnay/rust-toolchain`
- Update `docker/build-push-action` version

Removes all the warnings that were generated by those two actions ([example, see annotations section](https://github.com/esp-rs/esp-template/actions/runs/4062106301))