### PR TITLE
Add cargo-outdated check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         run: cargo install cargo-generate
       - name: Setup | cargo-outdated (binaries)
         if: matrix.action.command == 'outdated'
-        uses: dtolnay/install@v1
+        uses: dtolnay/install@master
         with:
           crate: cargo-outdated
       - name: Generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,10 @@ jobs:
       - name: Setup | cargo-generate (binaries)
         id: binaries
         continue-on-error: true
-        uses: dtolnay/install@master
-        with:
-          crate: cargo-generate
+        run: |
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
+          chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
@@ -89,9 +90,10 @@ jobs:
       - name: Setup | cargo-generate (binaries)
         id: binaries
         continue-on-error: true
-        uses: dtolnay/install@master
-        with:
-          crate: cargo-generate
+        run: |
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
+          chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,16 @@ jobs:
         action:
           - command: build
             args: --release
+            continue-on-error: false
           - command: fmt
             args: -- --check
+            continue-on-error: false
           - command: clippy
             args: --no-deps
+            continue-on-error: false
           - command: outdated
             args: --root-deps-only --exit-code 1 -v
+            continue-on-error: true
     steps:
       - uses: actions/checkout@v3
         with:
@@ -68,12 +72,13 @@ jobs:
         run: cargo install cargo-generate
       - name: Setup | cargo-outdated (binaries)
         if: matrix.action.command == 'outdated'
-        uses: dtolnay/install@master
+        uses: dtolnay/install@v1
         with:
           crate: cargo-outdated
       - name: Generate
         run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --name test --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=false -d alloc=${{ matrix.alloc }}
       - name: cargo ${{ matrix.action.command }}
+        continue-on-error: ${{ matrix.action.continue-on-error }}
         run: cd test; cargo ${{ matrix.action.command }} ${{ matrix.action.args }}
   docker-checks:
     name: Build project using the generated Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,48 @@ jobs:
           run: |
             cd /home/esp/test-${{ matrix.board }}
             bash -c 'source /home/esp/export-esp.sh && cargo build'
+  cargo-outdate-check:
+    name: cargo outdate - ${{ matrix.board }} (alloc=${{ matrix.alloc }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        board: ["esp32", "esp32s2", "esp32s3", "esp32c3"]
+        alloc: ["true", "false"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: /home/runner/work/esp-template/esp-template/github-esp-template
+      - name: Setup | Rust
+        if: matrix.board == 'esp32c3'
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          target: riscv32imc-unknown-none-elf
+          toolchain: nightly
+          components: clippy, rustfmt, rust-src
+      - name: Setup | Rust
+        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3'
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          default: true
+          buildtargets: ${{ matrix.board }}
+          ldproxy: false
+      - uses: Swatinem/rust-cache@v2
+      - name: Setup | cargo-generate (binaries)
+        id: binaries
+        continue-on-error: true
+        run: |
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
+          chmod u+x /home/runner/.cargo/bin/cargo-generate
+      - name: Setup | cargo-generate (cargo)
+        if: steps.binaries.outcome != 'success'
+        run: cargo install cargo-generate
+      - name: Setup | cargo-outdate
+        uses: dtolnay/install@master
+        with:
+          crate: cargo-outdated
+      - name: Generate
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --name test --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=false -d alloc=${{ matrix.alloc }}
+      - name: cargo ${{ matrix.action.command }}
+        run: cd test; cargo outdated --root-deps-only --exit-code 1 -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,9 @@ jobs:
       - name: Setup | cargo-generate (binaries)
         id: binaries
         continue-on-error: true
-        run: |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
-          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
-          chmod u+x /home/runner/.cargo/bin/cargo-generate
+        uses: dtolnay/install@master
+        with:
+          crate: cargo-generate
       - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
@@ -90,10 +89,9 @@ jobs:
       - name: Setup | cargo-generate (binaries)
         id: binaries
         continue-on-error: true
-        run: |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
-          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
-          chmod u+x /home/runner/.cargo/bin/cargo-generate
+        uses: dtolnay/install@master
+        with:
+          crate: cargo-generate
       - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
             args: -- --check
           - command: clippy
             args: --no-deps
+          - command: outdated
+            args: --root-deps-only --exit-code 1 -v
     steps:
       - uses: actions/checkout@v3
         with:
@@ -64,6 +66,11 @@ jobs:
       - name: Setup | cargo-generate (cargo)
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
+      - name: Setup | cargo-outdated (binaries)
+        if: matrix.action.command == 'outdated'
+        uses: dtolnay/install@master
+        with:
+          crate: cargo-outdated
       - name: Generate
         run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --name test --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=false -d alloc=${{ matrix.alloc }}
       - name: cargo ${{ matrix.action.command }}
@@ -110,48 +117,3 @@ jobs:
           run: |
             cd /home/esp/test-${{ matrix.board }}
             bash -c 'source /home/esp/export-esp.sh && cargo build'
-  cargo-outdate-check:
-    name: cargo outdate - ${{ matrix.board }} (alloc=${{ matrix.alloc }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        board: ["esp32", "esp32s2", "esp32s3", "esp32c3"]
-        alloc: ["true", "false"]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          path: /home/runner/work/esp-template/esp-template/github-esp-template
-      - name: Setup | Rust
-        if: matrix.board == 'esp32c3'
-        uses: dtolnay/rust-toolchain@v1
-        with:
-          target: riscv32imc-unknown-none-elf
-          toolchain: nightly
-          components: clippy, rustfmt, rust-src
-      - name: Setup | Rust
-        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3'
-        uses: esp-rs/xtensa-toolchain@v1.5
-        with:
-          default: true
-          buildtargets: ${{ matrix.board }}
-          ldproxy: false
-      - uses: Swatinem/rust-cache@v2
-      - name: Setup | cargo-generate (binaries)
-        id: binaries
-        continue-on-error: true
-        run: |
-          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
-          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
-          chmod u+x /home/runner/.cargo/bin/cargo-generate
-      - name: Setup | cargo-generate (cargo)
-        if: steps.binaries.outcome != 'success'
-        run: cargo install cargo-generate
-      - name: Setup | cargo-outdate
-        uses: dtolnay/install@master
-        with:
-          crate: cargo-outdated
-      - name: Generate
-        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --name test --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=false -d alloc=${{ matrix.alloc }}
-      - name: cargo ${{ matrix.action.command }}
-        run: cd test; cargo outdated --root-deps-only --exit-code 1 -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 {% if mcu == "esp32" -%}
-{{ mcu }}-hal = "0.8.0"
+{{ mcu }}-hal = "0.7.0"
 {% else -%}
 {{ mcu }}-hal = "0.5.0"
 {% endif -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 {% if mcu == "esp32" -%}
-{{ mcu }}-hal = "0.7.0"
+{{ mcu }}-hal = "0.8.0"
 {% else -%}
 {{ mcu }}-hal = "0.5.0"
 {% endif -%}


### PR DESCRIPTION
Add a [cargo-outdated](https://github.com/kbknapp/cargo-outdated) check that can help us maintain the dependencies up to date. 

Maybe this is not something we want, as sometimes we may not want to update some dependencies and it would result in a CI failure until its updated, let me know your thoughts and I am happy to close the PR if agreed