### PR TITLE
Fix runner command

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.{{ rust_target }}]
-runner = "espflash flash --monitor"
+runner = "espflash --monitor"
 
 [build]
 rustflags = [


### PR DESCRIPTION
There seems to have been a typo introduced in the runner command. There is no flash subcommand of espflash, and it causes the following error:

```
Error: espflash::connection_failed

  × Error while connecting to device
  ╰─▶ Serial port not found
```