### PR TITLE
Added release and dev profiles, matching those in the esp-idf-templat…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,13 @@ authors = ["{{ authors }}"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true # Symbols are nice and they don't increase the size on Flash
+opt-level = "z"
+
 [dependencies]
 hal = { package = "{{ mcu }}-hal", version = "{{ hal_version }}" }
 esp-backtrace = { version = "0.5.0", features = ["{{ mcu }}", "panic-handler", "print-uart"] }


### PR DESCRIPTION
This pull request adds profile sections to Cargo.toml for release and dev. It matches the esp-idf-template settings. 