### PR TITLE
Added config for espflash 1.* and 2.*

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,8 @@
 [target.{{ rust_target }}]
+# uncomment if using espflash 1.*
+# runner = "espflash --monitor"
+
+# uncomment if using espflash 2.*
 runner = "espflash flash --monitor"
 
 [build]


### PR DESCRIPTION
I am not sure if this is the cleanest way to support this, but the `espflash` command is different for espflash 1.* and 2.*, so while 2.* is not the only version in the wild, we need some kind of hand-holding to get people to use the correct one. Short of auto-detecting the version, I thought having a commented section in the config was the simplest option. I was confused by this as a complete noob, and the two templates assume different versions of espflash are installed which threw me for a loop.