### PR TITLE
Fix typo in web-flash command

### DIFF
--- a/scripts/flash.sh
+++ b/scripts/flash.sh
@@ -18,4 +18,4 @@ case "$1" in
     ;;
 esac
 
-web-flash --chip {{ mcu }} target/{{ rust_target }}xº/${BUILD_MODE}/{{ crate_name }}
+web-flash --chip {{ mcu }} target/{{ rust_target }}/${BUILD_MODE}/{{ crate_name }}


### PR DESCRIPTION
There were some characters included by error and spotted by @AngelOnFira 