### PR TITLE
Add `exception-handler` feature for esp-backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 hal = { package = "{{ mcu }}-hal", version = "{{ hal_version }}" }
-esp-backtrace = { version = "0.6.0", features = ["{{ mcu }}", "panic-handler", "print-uart"] }
+esp-backtrace = { version = "0.6.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }
 esp-println       = { version = "0.4.0", features = ["{{ mcu }}"] }
 {% if alloc -%}
 esp-alloc = { version = "0.2.0", features = ["oom-handler"] }

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">=0.10.0"
+cargo_generate_version = ">=0.14.0"
 ignore = [".git", ".github", "README.md"]
 
 [hooks]

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,1 +1,10 @@
 system::command("cargo", ["fmt"]);
+
+// remove this output once espflash 2.x is default
+print();
+print();
+print("💡 When using `espflash` version 1.x you need to edit `.cargo/config.toml`");
+print("💡 Make the runner look like this `runner = \"espflash --monitor\"`");
+print();
+print("Use `cargo run` to flash and run your code");
+print();


### PR DESCRIPTION
This adds the `exception-handler` feature to `esp-backtrace` (just because it took me half a day to realize it wasn't included trying to find a bug related to an exception)

Additionally, it bumps the min cargo-generate version to 0.14 since that seems to be the first version supporting the features used in our template.

It also prints a hint regarding what to do when using `espflash` version 1.x (hopefully we can remove that soon)
