### PR TITLE
Bump minimum required cargo-generate version

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,5 +1,5 @@
 [template]
-cargo_generate_version = ">=0.14.0"
+cargo_generate_version = ">=0.17.4"
 ignore = [".git", ".github", "README.md"]
 
 [hooks]


### PR DESCRIPTION
Just did some testing and verified that [`0.17.4`](https://github.com/cargo-generate/cargo-generate/releases/tag/v0.17.4) is the required version for shorten git URLs to work.

This version was released in Dec 2022, if you think we shouldn't force the user to such “recent” version (although updating cargo-generate does not hurt) we could go back to the full URL