### PR TITLE
Update rust-toolchain file for RISC-V targets

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,4 @@
+# Base image
 ARG VARIANT=bullseye-slim
 FROM debian:${VARIANT}
 ENV DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -2,10 +2,10 @@ name: Container CI
 on:
   push:
     paths:
-      - "**/.devcontainer/**"
+      - ".devcontainer/Dockerfile"
   pull_request:
     paths:
-      - "**/.devcontainer/**"
+      - ".devcontainer/Dockerfile"
   schedule:
     - cron: "50 7 * * *"
 

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -45,7 +45,7 @@ jobs:
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
       - name: Generate
-        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d devcontainer=true -d wokwi=false -d alloc=false
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d defaults=false -d devcontainer=true -d wokwi=false -d alloc=false
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.board }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # esp-template
 [![CI](https://github.com/esp-rs/esp-template/actions/workflows/ci.yml/badge.svg)](https://github.com/esp-rs/esp-template/actions/workflows/ci.yml)
+[![Container CI](https://github.com/esp-rs/esp-template/actions/workflows/ci_docker.yml/badge.svg)](https://github.com/esp-rs/esp-template/actions/workflows/ci_docker.yml)
 
 A minimalist template for use with [cargo-generate] to create `no_std` applications targeting Espressif's line of SoCs and modules. At present, this template supports the **ESP32**, **ESP32-C2**, **ESP32-C3**,**ESP32-C6**, **ESP32-S2**, and **ESP32-S3**; additional devices will be added as they become available.
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 channel = "{{ toolchain }}"
-{%- if toolchain == "nightly" %}
+{%- if arch == "riscv" %}
 components = ["rust-src"]
 targets = ["{{ rust_target }}"]
 {% endif %}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,6 @@
 [toolchain]
 channel = "{{ toolchain }}"
+{%- if toolchain == "nightly" %}
+components = ["rust-src"]
+targets = ["riscv32imc-unknown-none-elf"]
+{% endif %}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 channel = "{{ toolchain }}"
 {%- if toolchain == "nightly" %}
 components = ["rust-src"]
-targets = ["riscv32imc-unknown-none-elf"]
+targets = ["{{ rust_target }}"]
 {% endif %}


### PR DESCRIPTION
- `rust-toolchain.toml` now includes components and targets properties for RISC-V targets
- Fix Container CI prompts
- Add Container CI badge in the Readme