### PR TITLE
Use latest HAL releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
       - "**/README.md"
   schedule:
     - cron: "50 7 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -8,6 +8,7 @@ on:
       - ".devcontainer/Dockerfile"
   schedule:
     - cron: "50 7 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -9,7 +9,7 @@ let targets = #{
         rust_target: "xtensa-esp32-none-elf",
         atomic_emulation: "none",
         gcc_target: "xtensa-esp32-elf",
-        hal_version: "0.11.0",
+        hal_version: "0.12.0",
         wokwi_board: "board-esp32-devkit-v1",
     },
     esp32s2: #{
@@ -22,7 +22,7 @@ let targets = #{
         rust_target: "xtensa-esp32s2-none-elf",
         atomic_emulation: "esp32s2",
         gcc_target: "xtensa-esp32s2-elf",
-        hal_version: "0.8.0",
+        hal_version: "0.9.0",
         wokwi_board: "board-esp32-s2-devkitm-1",
     },
     esp32s3: #{
@@ -35,7 +35,7 @@ let targets = #{
         rust_target: "xtensa-esp32s3-none-elf",
         atomic_emulation: "none",
         gcc_target: "xtensa-esp32s3-elf",
-        hal_version: "0.8.0",
+        hal_version: "0.9.0",
         wokwi_board: "board-esp32-s3-devkitc-1",
     },
     esp32c2: #{
@@ -48,7 +48,7 @@ let targets = #{
         rust_target: "riscv32imc-unknown-none-elf",
         atomic_emulation: "riscv",
         gcc_target: "riscv32-esp-elf",
-        hal_version: "0.6.0",
+        hal_version: "0.7.0",
         wokwi_board: "",
     },
     esp32c3: #{
@@ -61,7 +61,7 @@ let targets = #{
         rust_target: "riscv32imc-unknown-none-elf",
         atomic_emulation: "riscv",
         gcc_target: "riscv32-esp-elf",
-        hal_version: "0.8.0",
+        hal_version: "0.9.0",
         wokwi_board: "board-esp32-c3-devkitm-1",
     },
     esp32c6: #{
@@ -74,7 +74,7 @@ let targets = #{
         rust_target: "riscv32imac-unknown-none-elf",
         atomic_emulation: "none",
         gcc_target: "riscv32-esp-elf",
-        hal_version: "0.1.0",
+        hal_version: "0.2.0",
         wokwi_board: "board-esp32-c6-devkitc-1",
     },
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,15 +40,23 @@ fn main() -> ! {
     init_heap();
     {%- endif %}
     let peripherals = Peripherals::take();
-    let system = peripherals.{{ sys_peripheral }}.split();
+    let mut system = peripherals.{{ sys_peripheral }}.split();
     let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
 
     // Disable the RTC and TIMG watchdog timers
     let mut rtc = Rtc::new(peripherals.{{ rct_peripheral }});
-    let timer_group0 = TimerGroup::new(peripherals.TIMG0, &clocks);
+    let timer_group0 = TimerGroup::new(
+        peripherals.TIMG0,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let mut wdt0 = timer_group0.wdt;
     {% if has_tg1 -%}
-    let timer_group1 = TimerGroup::new(peripherals.TIMG1, &clocks);
+    let timer_group1 = TimerGroup::new(
+        peripherals.TIMG1,
+        &clocks,
+        &mut system.peripheral_clock_control,
+    );
     let mut wdt1 = timer_group1.wdt;
     {% endif -%}
 


### PR DESCRIPTION
I've also allowed manual dispatch of CI workflows, just because it's convenient to have (and my fork of the repo didn't run the workflows on first push...)