### PR TITLE
added option to add support for the log crate

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,12 @@
 [target.{{ rust_target }}]
 runner = "espflash flash --monitor"
 
+
+{% if logging -%}
+[env]
+ESP_LOGLEVEL="DEBUG"
+{% endif -%}
+
 [build]
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       matrix:
         board: ["esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
         alloc: ["true", "false"]
+        loggign: ["true", "false"]
         action:
           - command: build
             args: --release
@@ -68,6 +69,6 @@ jobs:
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
       - name: Generate
-        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=false -d wokwi=false -d alloc=${{ matrix.alloc }} -d ci=false
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=false -d wokwi=false -d alloc=${{ matrix.alloc }} -d ci=false -d logging=${{ matrix.logging }}
       - name: cargo ${{ matrix.action.command }}
         run: cd test; cargo ${{ matrix.action.command }} ${{ matrix.action.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         board: ["esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
         alloc: ["true", "false"]
-        loggign: ["true", "false"]
+        logging: ["true", "false"]
         action:
           - command: build
             args: --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 hal = { package = "{{ mcu }}-hal", version = "{{ hal_version }}" }
 esp-backtrace = { version = "0.7.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }
+{% if logging -%}
+esp-println       = { version = "0.5.0", features = ["{{ mcu }}","log"] }
+log = { version = "0.4.18" }
+{% else -%}
 esp-println       = { version = "0.5.0", features = ["{{ mcu }}"] }
+{% endif -%}
 {% if alloc -%}
-esp-alloc = { version = "0.3.0"}
+esp-alloc = { version = "0.3.0" }
 {% endif -%}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ After running the command, there will be a few prompts:
 - `Configure advanced template options?`: If `false`, skips the rest of the prompts and uses their default value. If `true`, you will be prompted with:
   - `Enable allocations via the esp-alloc crate?`: Adds [`esp-alloc`] dependency, and initializes the heap.
   - `Configure project to support Wokwi simulation with Wokwi VS Code extension?`: Adds support for Wokwi simulation using [VS Code Wokwi extension].
+  - `Setup logging using the log crate?`: Adds [`log`] dependency and initializes logging.
   - `Configure project to use Dev Containers (VS Code and GitHub Codespaces)?`: Adds support for:
      -  [VS Code Dev Containers]
      -  [GitHub Codespaces]
@@ -31,9 +32,9 @@ For a more detailed explanation about the template, see [Understanding esp-templ
 [Wokwi simulator]: https://wokwi.com/
 [VS Code Wokwi extension]: https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode
 [web flash]: https://github.com/bjoernQ/esp-web-flash-server
-[Understanding esp-template]: https://esp-rs.github.io/book/writing-your-own-application/no-std-applications/understanding-esp-template.html
+[Understanding esp-template]: https://esp-rs.github.io/book/writing-your-own-application/generate-project/esp-template.html
 [The Rust on ESP Book]: https://esp-rs.github.io/book/
-
+[`log`]: https://docs.rs/log/latest/log/
 
 ## License
 

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -36,6 +36,11 @@ type = "bool"
 prompt = "Add CI files for GitHub Action?"
 default = false
 
+[conditional.'advanced'.placeholders.logging]
+type = "bool"
+prompt = "Setup logging using the log crate?"
+default = false
+
 [conditional.'!devcontainer']
 ignore = [
     ".devcontainer/",

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -103,4 +103,5 @@ if !advanced {
     variable::set("alloc", false);
     variable::set("devcontainer", false);
     variable::set("wokwi", false);
+    variable::set("logging", false);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use esp_backtrace as _;
 use esp_println::println;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 {% if logging -%}
-use log::{info};
+use log::info;
 {% endif -%}
 
 {%- if alloc %}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,11 @@ extern crate alloc;
 use esp_backtrace as _;
 use esp_println::println;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
+{% if logging -%}
+use log::{LevelFilter,info};
+use core::str::FromStr;
+{% endif -%}
+
 {%- if alloc %}
 #[global_allocator]
 static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
@@ -67,6 +72,17 @@ fn main() -> ! {
     wdt0.disable();
     {% if has_tg1 -%}
     wdt1.disable();
+    {% endif -%}
+
+    {% if logging -%}
+    // setup logger
+    const LEVEL: Option<&'static str> = option_env!("ESP_LOGLEVEL");
+    let filter = match LEVEL {
+        Some(lvl) => LevelFilter::from_str(lvl).unwrap_or_else(|_| LevelFilter::Info),
+        None => LevelFilter::Info,
+    };
+    esp_println::logger::init_logger(filter);
+    info!("Logger is setup");
     {% endif -%}
 
     println!("Hello world!");

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,7 @@ use esp_backtrace as _;
 use esp_println::println;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, timer::TimerGroup, Rtc};
 {% if logging -%}
-use log::{LevelFilter,info};
-use core::str::FromStr;
+use log::{info};
 {% endif -%}
 
 {%- if alloc %}
@@ -76,15 +75,13 @@ fn main() -> ! {
 
     {% if logging -%}
     // setup logger
-    const LEVEL: Option<&'static str> = option_env!("ESP_LOGLEVEL");
-    let filter = match LEVEL {
-        Some(lvl) => LevelFilter::from_str(lvl).unwrap_or_else(|_| LevelFilter::Info),
-        None => LevelFilter::Info,
-    };
-    esp_println::logger::init_logger(filter);
+    // To change the log_level change the env section in .config/cargo.toml
+    // or remove it and set ESP_LOGLEVEL manually before running cargo run
+    // this requires a clean rebuild because of https://github.com/rust-lang/cargo/issues/10358
+    esp_println::logger::init_logger_from_env();
     info!("Logger is setup");
     {% endif -%}
-
+ 
     println!("Hello world!");
 
     loop {}


### PR DESCRIPTION
This just adds another option in the advanced section that adds a dependency to the log crate and initializes the logger from esp_println

Also fixed a broken link to the esp-template section in the book