### PR TITLE
Update esp-println/esp-backtrace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 hal = { package = "{{ mcu }}-hal", version = "{{ hal_version }}" }
-esp-backtrace = { version = "0.7.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }
+esp-backtrace = { version = "0.8.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }
 {% if logging -%}
-esp-println       = { version = "0.5.0", features = ["{{ mcu }}","log"] }
+esp-println       = { version = "0.6.0", features = ["{{ mcu }}","log"] }
 log = { version = "0.4.18" }
 {% else -%}
-esp-println       = { version = "0.5.0", features = ["{{ mcu }}"] }
+esp-println       = { version = "0.6.0", features = ["{{ mcu }}"] }
 {% endif -%}
 {% if alloc -%}
 esp-alloc = { version = "0.3.0" }


### PR DESCRIPTION
`esp-println` and `esp-backtrace` got new releases on crates.io.
This bumps the version numbers
