### PR TITLE
Add esp-wifi support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,7 +10,9 @@ ESP_LOGLEVEL="DEBUG"
 [build]
 rustflags = [
   "-C", "link-arg=-Tlinkall.x",
-
+{% if wifi -%}
+  "-C", "link-arg=-Trom_functions.x",
+{% endif -%}
 {%- if arch == "xtensa" %}
   "-C", "link-arg=-nostartfiles",
 {% else %}

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ runner = "espflash flash --monitor"
 
 {% if logging -%}
 [env]
-ESP_LOGLEVEL="DEBUG"
+ESP_LOGLEVEL="INFO"
 {% endif -%}
 
 [build]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - command: fmt
             args: -- --check
           - command: clippy
-            args: --no-deps -- -D warnings -A dead_code
+            args: --no-deps -- -D warnings -A dead_code -A empty_loop
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
       - name: Generate
+        if: matrix.board == 'esp32h2'
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=false -d wokwi=false -d alloc=${{ matrix.alloc }} -d ci=false -d logging=${{ matrix.logging }}
+      - name: Generate
+        if: matrix.board != 'esp32h2'
         run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=false -d wokwi=false -d alloc=${{ matrix.alloc }} -d wifi=${{ matrix.wifi }} -d ci=false -d logging=${{ matrix.logging }}
       - name: cargo ${{ matrix.action.command }}
         run: cd test; cargo ${{ matrix.action.command }} ${{ matrix.action.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SSID: SSID
+  PASSWORD: PASSWORD
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.
@@ -24,7 +26,7 @@ concurrency:
 
 jobs:
   rust-checks:
-    name: cargo ${{ matrix.action.command }} - ${{ matrix.board }} (alloc=${{ matrix.alloc }} logging=${{ matrix.logging }})
+    name: cargo ${{ matrix.action.command }} - ${{ matrix.board }} (alloc=${{ matrix.alloc }} wifi=${{ matrix.wifi }} logging=${{ matrix.logging }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -32,6 +34,7 @@ jobs:
         board: ["esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
         alloc: ["true", "false"]
         logging: ["true", "false"]
+        wifi: ["true", "false"]
         action:
           - command: build
             args: --release
@@ -69,6 +72,6 @@ jobs:
         if: steps.binaries.outcome != 'success'
         run: cargo install cargo-generate
       - name: Generate
-        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=false -d wokwi=false -d alloc=${{ matrix.alloc }} -d ci=false -d logging=${{ matrix.logging }}
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=false -d wokwi=false -d alloc=${{ matrix.alloc }} -d wifi=${{ matrix.wifi }} -d ci=false -d logging=${{ matrix.logging }}
       - name: cargo ${{ matrix.action.command }}
         run: cd test; cargo ${{ matrix.action.command }} ${{ matrix.action.args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           - command: fmt
             args: -- --check
           - command: clippy
-            args: --no-deps -- -D warnings -A dead_code -A empty_loop
+            args: --no-deps -- -D warnings -A dead_code -A clippy::empty_loop
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ esp-println = { version = "0.6.0", features = ["{{ mcu }}"] }
 esp-alloc = { version = "0.3.0" }
 {% endif -%}
 {% if wifi -%}
-esp-wifi        = { git = "https://github.com/esp-rs/esp-wifi/", features = ["{{ mcu }}", "wifi-logs", "wifi"] }
+esp-wifi        = { git = "https://github.com/esp-rs/esp-wifi/", rev = "fbb8417", features = ["{{ mcu }}", "wifi-logs", "wifi"] }
 smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 embedded-svc = { version = "0.25.0", default-features = false, features = [] }
 embedded-io = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ esp-println = { version = "0.6.0", features = ["{{ mcu }}"] }
 esp-alloc = { version = "0.3.0" }
 {% endif -%}
 {% if wifi -%}
-esp-wifi        = { git = "https://github.com/esp-rs/esp-wifi/", rev = "fbb8417", features = ["{{ mcu }}", "wifi-logs", "wifi"] }
+esp-wifi  = { git = "https://github.com/esp-rs/esp-wifi/", rev = "fbb8417", features = ["{{ mcu }}", "wifi"] }
 smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
 embedded-svc = { version = "0.25.0", default-features = false, features = [] }
 embedded-io = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,10 @@ esp-println = { version = "0.6.0", features = ["{{ mcu }}"] }
 {% if alloc -%}
 esp-alloc = { version = "0.3.0" }
 {% endif -%}
+{% if wifi -%}
+esp-wifi        = { git = "https://github.com/esp-rs/esp-wifi/", features = ["{{ mcu }}", "wifi-logs", "wifi"] }
+smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
+embedded-svc = { version = "0.25.0", default-features = false, features = [] }
+embedded-io = "0.4.0"
+heapless = { version = "0.7.14", default-features = false }
+{% endif -%}

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -21,7 +21,7 @@ type = "bool"
 prompt = "Enable allocations via the esp-alloc crate?"
 default = false
 
-[conditional.'advanced'.placeholders.wifi]
+[conditional.'advanced && mcu != "esp32h2"'.placeholders.wifi]
 type    = "bool"
 prompt  = "Enable WiFi/Bluetooth/ESP-NOW via the esp-wifi crate?"
 default = false

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -4,6 +4,7 @@ ignore = [".git", ".github/dependabot.yml", ".github/workflows/ci_docker.yml", "
 
 [hooks]
 pre = ["pre-script.rhai"]
+post = ["post-script.rhai"]
 
 [placeholders.mcu]
 type = "string"

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -21,6 +21,11 @@ type = "bool"
 prompt = "Enable allocations via the esp-alloc crate?"
 default = false
 
+[conditional.'advanced'.placeholders.wifi]
+type    = "bool"
+prompt  = "Enable WiFi/Bluetooth/ESP-NOW via the esp-wifi crate?"
+default = false
+
 [conditional.'advanced'.placeholders.devcontainer]
 type = "bool"
 prompt = "Configure project to use Dev Containers (VS Code and GitHub Codespaces)?"

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,0 +1,4 @@
+let wifi = variable::get("wifi");
+if wifi {
+    print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/examples.md\n");
+}

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,4 +1,3 @@
-let wifi = variable::get("wifi");
-if wifi {
+if variable::get("mcu") != "esp32h2" && variable::get("wifi"){
     print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/examples.md\n");
 }

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,3 +1,3 @@
-if variable::get("wifi"){
+if variable::get("mcu") != "esp32h2" && variable::get("wifi"){
     print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/examples.md\n");
 }

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,3 +1,3 @@
-if variable::get("mcu") != "esp32h2" && variable::get("wifi"){
+if variable::get("wifi"){
     print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/examples.md\n");
 }

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -104,4 +104,5 @@ if !advanced {
     variable::set("devcontainer", false);
     variable::set("wokwi", false);
     variable::set("logging", false);
+    variable::set("wifi", false);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> ! {
         &clocks,
     )
     .unwrap();
-    let (wifi, _) = peripherals.RADIO.split();
+    let (wifi, ..) = peripherals.RADIO.split();
     let mut socket_set_entries: [SocketStorage; 3] = Default::default();
     let (iface, device, mut controller, sockets) =
         create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     {%- endif %}
     let peripherals = Peripherals::take();
     let system = peripherals.{{ sys_peripheral }}.split();
-    let clocks = ClockControl::boot_defaults(system.clock_control).freeze();
+    let clocks = ClockControl::max(system.clock_control).freeze();
     let mut delay = Delay::new(&clocks);
 
     {% if logging -%}

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,6 @@ fn main() -> ! {
         }
     }
     {% endif -%}
-
     loop {
         println!("Loop...");
         delay.delay_ms(500u32);

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,16 +20,14 @@ use esp_wifi::{
     wifi_interface::WifiStack,
     EspWifiInitFor,
 };
+
 {% if arch == "riscv" -%}
 use hal::{systimer::SystemTimer, Rng};
 {% else -%}
-use hal::Rng;
+use hal::{timer::TimerGroup, Rng};
 {% endif -%}
 
 use smoltcp::iface::SocketStorage;
-{% endif -%}
-{% if logging -%}
-use log::info;
 {% endif -%}
 
 {% if wifi -%}
@@ -71,14 +69,14 @@ fn main() -> ! {
     // or remove it and set ESP_LOGLEVEL manually before running cargo run
     // this requires a clean rebuild because of https://github.com/rust-lang/cargo/issues/10358
     esp_println::logger::init_logger_from_env();
-    info!("Logger is setup");
+    log::info!("Logger is setup");
     {% endif -%}
     println!("Hello world!");
     {% if wifi -%}
     {% if arch == "riscv" -%}
     let timer = SystemTimer::new(peripherals.SYSTIMER).alarm0;
     {% else -%}
-    let timer = hal::timer::TimerGroup::new(
+    let timer = TimerGroup::new(
         peripherals.TIMG1,
         &clocks,
         &mut system.peripheral_clock_control,

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,28 @@ use core::mem::MaybeUninit;
 use esp_backtrace as _;
 use esp_println::println;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay};
+
+{% if wifi -%}
+use embedded_svc::{
+    ipv4::Interface,
+    wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wifi},
+};
+use esp_wifi::{
+    current_millis, initialize,
+    wifi::{utils::create_network_interface, WifiError, WifiMode},
+    wifi_interface::WifiStack,
+    EspWifiInitFor,
+};
+use hal::{systimer::SystemTimer, Rng};
+use smoltcp::iface::SocketStorage;
+{% endif -%}
 {% if logging -%}
 use log::info;
+{% endif -%}
+
+{% if wifi -%}
+const SSID: &str = env!("SSID");
+const PASSWORD: &str = env!("PASSWORD");
 {% endif -%}
 
 {%- if alloc %}
@@ -45,6 +65,74 @@ fn main() -> ! {
     {% endif -%}
 
     println!("Hello world!");
+
+
+    {% if wifi -%}
+    let timer = SystemTimer::new(peripherals.SYSTIMER).alarm0;
+    let init = initialize(
+        EspWifiInitFor::Wifi,
+        timer,
+        Rng::new(peripherals.RNG),
+        system.radio_clock_control,
+        &clocks,
+    )
+    .unwrap();
+    let (wifi, _) = peripherals.RADIO.split();
+    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
+    let (iface, device, mut controller, sockets) =
+        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();
+    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
+    let client_config = Configuration::Client(ClientConfiguration {
+        ssid: SSID.into(),
+        password: PASSWORD.into(),
+        ..Default::default()
+    });
+    let res = controller.set_configuration(&client_config);
+    println!("Wi-Fi set_configuration returned {:?}", res);
+
+    controller.start().unwrap();
+    println!("Is wifi started: {:?}", controller.is_started());
+
+    println!("Start Wifi Scan");
+    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = controller.scan_n();
+    if let Ok((res, _count)) = res {
+        for ap in res {
+            println!("{:?}", ap);
+        }
+    }
+
+    println!("{:?}", controller.get_capabilities());
+    println!("Wi-Fi connect: {:?}", controller.connect());
+
+    // Wait to get connected
+    println!("Wait to get connected");
+    loop {
+        let res = controller.is_connected();
+        match res {
+            Ok(connected) => {
+                if connected {
+                    break;
+                }
+            }
+            Err(err) => {
+                println!("{:?}", err);
+                loop {}
+            }
+        }
+    }
+    println!("{:?}", controller.is_connected());
+
+    // Wait for getting an ip address
+    println!("Wait to get an ip address");
+    loop {
+        wifi_stack.work();
+
+        if wifi_stack.is_iface_up() {
+            println!("got ip {:?}", wifi_stack.get_ip_info());
+            break;
+        }
+    }
+    {% endif -%}
 
     loop {
         println!("Loop...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,29 +10,13 @@ use esp_println::println;
 use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay};
 
 {% if wifi -%}
-use embedded_svc::{
-    ipv4::Interface,
-    wifi::{AccessPointInfo, ClientConfiguration, Configuration, Wifi},
-};
-use esp_wifi::{
-    current_millis, initialize,
-    wifi::{utils::create_network_interface, WifiError, WifiMode},
-    wifi_interface::WifiStack,
-    EspWifiInitFor,
-};
+use esp_wifi::{initialize, EspWifiInitFor};
 
 {% if arch == "riscv" -%}
 use hal::{systimer::SystemTimer, Rng};
 {% else -%}
 use hal::{timer::TimerGroup, Rng};
 {% endif -%}
-
-use smoltcp::iface::SocketStorage;
-{% endif -%}
-
-{% if wifi -%}
-const SSID: &str = env!("SSID");
-const PASSWORD: &str = env!("PASSWORD");
 {% endif -%}
 
 {% if alloc -%}
@@ -83,7 +67,7 @@ fn main() -> ! {
     )
     .timer0;
     {% endif -%}
-    let init = initialize(
+    let _init = initialize(
         EspWifiInitFor::Wifi,
         timer,
         Rng::new(peripherals.RNG),
@@ -91,65 +75,6 @@ fn main() -> ! {
         &clocks,
     )
     .unwrap();
-    {% if mcu == "esp32s2" -%}
-    let wifi = peripherals.RADIO.split();
-    {% else -%}
-    let (wifi, ..) = peripherals.RADIO.split();
-    {% endif -%}
-    let mut socket_set_entries: [SocketStorage; 3] = Default::default();
-    let (iface, device, mut controller, sockets) =
-        create_network_interface(&init, wifi, WifiMode::Sta, &mut socket_set_entries).unwrap();
-    let wifi_stack = WifiStack::new(iface, device, sockets, current_millis);
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
-    });
-    let res = controller.set_configuration(&client_config);
-    println!("Wi-Fi set_configuration returned {:?}", res);
-
-    controller.start().unwrap();
-    println!("Is wifi started: {:?}", controller.is_started());
-
-    println!("Start Wifi Scan");
-    let res: Result<(heapless::Vec<AccessPointInfo, 10>, usize), WifiError> = controller.scan_n();
-    if let Ok((res, _count)) = res {
-        for ap in res {
-            println!("{:?}", ap);
-        }
-    }
-
-    println!("{:?}", controller.get_capabilities());
-    println!("Wi-Fi connect: {:?}", controller.connect());
-
-    // Wait to get connected
-    println!("Wait to get connected");
-    loop {
-        let res = controller.is_connected();
-        match res {
-            Ok(connected) => {
-                if connected {
-                    break;
-                }
-            }
-            Err(err) => {
-                println!("{:?}", err);
-                loop {}
-            }
-        }
-    }
-    println!("{:?}", controller.is_connected());
-
-    // Wait for getting an ip address
-    println!("Wait to get an ip address");
-    loop {
-        wifi_stack.work();
-
-        if wifi_stack.is_iface_up() {
-            println!("got ip {:?}", wifi_stack.get_ip_info());
-            break;
-        }
-    }
     {% endif -%}
     loop {
         println!("Loop...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,7 @@ use esp_wifi::{
 use hal::{systimer::SystemTimer, Rng};
 {% else -%}
 use hal::Rng;
-{% if logging -%}
-
+{% endif -%}
 use smoltcp::iface::SocketStorage;
 {% endif -%}
 {% if logging -%}
@@ -68,10 +67,7 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     info!("Logger is setup");
     {% endif -%}
-
     println!("Hello world!");
-
-
     {% if wifi -%}
     {%- if arch == "riscv" %}
     let timer = SystemTimer::new(peripherals.SYSTIMER).alarm0;
@@ -83,7 +79,6 @@ fn main() -> ! {
     )
     .timer0;
     {% endif -%}
-
     let init = initialize(
         EspWifiInitFor::Wifi,
         timer,


### PR DESCRIPTION
Initial esp-wifi support, when enabled it adds the code to connect to a Wifi network
Downsides:
- It introduces a lot of `if`s
- Only adds support for Wifi, not BLE and ESP-NOW
- Imports are weirdly ordered in some combinations (`rustfmt` does not complain but still weird)
- Number of CI jobs is huge (168)
