### PR TITLE
Remove --all-targets clippy argument

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -26,7 +26,7 @@ jobs:
           - command: fmt
             args: --all -- --check --color always
           - command: clippy
-            args: --all-targets --all-features --workspace -- -D warnings
+            args: --all-features --workspace -- -D warnings
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The `--all-targets` is trying to build all targets in test mode and that fails. More info in https://doc.rust-lang.org/cargo/commands/cargo-build.html#target-selection