### PR TITLE
Fix template when not using advanced prompts

### DIFF
--- a/.github/verify.sh
+++ b/.github/verify.sh
@@ -18,11 +18,9 @@ perform_checks() {
     cd ..
 }
 
-simple_wifi_arg=""
 complex_wifi_arg=""
 # H2 has no wifi
 if [ "$1" != "esp32h2" ]; then
-    simple_wifi_arg="-d wifi=false"
     complex_wifi_arg="-d wifi=true"
 fi
 
@@ -30,12 +28,11 @@ fi
 cargo generate \
     --path $template_path --name=test-complex --silent --vcs=none \
     -d advanced=true -d ci=false -d devcontainer=false -d wokwi=false \
-    -d alloc=true -d logging=true $simple_wifi_arg -d mcu=$1
+    -d alloc=true -d logging=true $complex_wifi_arg -d mcu=$1
 
 cargo generate \
     --path $template_path --name=test-simple --silent --vcs=none \
-    -d advanced=true -d ci=false -d devcontainer=false -d wokwi=false \
-    -d alloc=false -d logging=false $complex_wifi_arg -d mcu=$1
+    -d advanced=false -d mcu=$1
 
 # Perform checks
 perform_checks test-complex

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -73,8 +73,10 @@ if mcu in ["esp32", "esp32s2", "esp32s3"] {
 let advanced = variable::get("advanced");
 if !advanced {
     variable::set("alloc", false);
+    variable::set("ci", false);
     variable::set("devcontainer", false);
     variable::set("wokwi", false);
     variable::set("logging", false);
     variable::set("wifi", false);
+
 }

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -78,5 +78,4 @@ if !advanced {
     variable::set("wokwi", false);
     variable::set("logging", false);
     variable::set("wifi", false);
-
 }


### PR DESCRIPTION
See #133. Also fixed/improved the script by:
- Used `advanced=flase` instead of listing all the prompts
- The wifi arg was swapped between simple and complex. Now, the simple is not required.