### PR TITLE
Fixed embedded-svc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ esp-alloc = { version = "0.3.0" }
 {% if wifi -%}
 esp-wifi  = { version = "0.1.1", features = ["{{ mcu }}", "wifi"] }
 smoltcp = { version = "0.10.0", default-features=false, features = ["proto-igmp", "proto-ipv4", "socket-tcp", "socket-icmp", "socket-udp", "medium-ethernet", "proto-dhcpv4", "socket-raw", "socket-dhcpv4"] }
-embedded-svc = { version = "0.25.0", default-features = false, features = [] }
+embedded-svc = { version = "0.26.1", default-features = false, features = [] }
 embedded-io = "0.4.0"
 heapless = { version = "0.7.14", default-features = false }
 {% endif -%}


### PR DESCRIPTION
The version of embedded-svc in esp-wifi 0.1.1 is 0.26.1 and using an older one leads to trait conflicts which are hard to find out.

See https://github.com/esp-rs/esp-wifi/blob/v0.1.1/Cargo.toml

I encountered this error where a trait was implemented but not in scope, despite having the right imports. Turns out after using the trait function explicitly, that two versions of the trait are used. Fixing the version in the Cargo.toml fixed this for me.

Also: Happy new year!