### PR TITLE
Complete esp32h2 support, simplify linker args, create snippets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,10 +9,6 @@ ESP_LOGLEVEL="INFO"
 
 [build]
 rustflags = [
-  "-C", "link-arg=-Tlinkall.x",
-{% if wifi %}
-  "-C", "link-arg=-Trom_functions.x",
-{% endif -%}
 {%- if arch == "xtensa" %}
   "-C", "link-arg=-nostartfiles",
 {% else %}

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,10 +2,8 @@
 runner = "espflash flash --monitor"
 
 
-{% if logging -%}
 [env]
 ESP_LOGLEVEL="INFO"
-{% endif -%}
 
 [build]
 rustflags = [

--- a/.github/verify.sh
+++ b/.github/verify.sh
@@ -22,11 +22,13 @@ perform_checks() {
 
 # Generate templates
 cargo generate \
+    -a \
     --path $template_path --name=test-complex --silent --vcs=none \
     -d advanced=true -d ci=false -d devcontainer=false -d wokwi=false \
     -d alloc=true -d wifi=true -d mcu=$1
 
 cargo generate \
+    -a \
     --path $template_path --name=test-simple --silent --vcs=none \
     -d advanced=false -d mcu=$1
 

--- a/.github/verify.sh
+++ b/.github/verify.sh
@@ -20,13 +20,11 @@ perform_checks() {
     cd ..
 }
 
-complex_wifi_arg=""
-
 # Generate templates
 cargo generate \
     --path $template_path --name=test-complex --silent --vcs=none \
     -d advanced=true -d ci=false -d devcontainer=false -d wokwi=false \
-    -d alloc=true $complex_wifi_arg -d mcu=$1
+    -d alloc=true -d wifi=true -d mcu=$1
 
 cargo generate \
     --path $template_path --name=test-simple --silent --vcs=none \

--- a/.github/verify.sh
+++ b/.github/verify.sh
@@ -21,16 +21,12 @@ perform_checks() {
 }
 
 complex_wifi_arg=""
-# H2 has no wifi
-if [ "$1" != "esp32h2" ]; then
-    complex_wifi_arg="-d wifi=true"
-fi
 
 # Generate templates
 cargo generate \
     --path $template_path --name=test-complex --silent --vcs=none \
     -d advanced=true -d ci=false -d devcontainer=false -d wokwi=false \
-    -d alloc=true -d logging=true $complex_wifi_arg -d mcu=$1
+    -d alloc=true $complex_wifi_arg -d mcu=$1
 
 cargo generate \
     --path $template_path --name=test-simple --silent --vcs=none \

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -47,10 +47,10 @@ jobs:
         run: cargo install cargo-generate
       - name: Generate
         if: matrix.board == 'esp32h2'
-        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=true -d wokwi=false -d alloc=false -d ci=false -d logging=false
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d devcontainer=true -d wokwi=false -d alloc=false -d ci=false
       - name: Generate
         if: matrix.board != 'esp32h2'
-        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d wifi=false -d devcontainer=true -d wokwi=false -d alloc=false -d ci=false -d logging=false
+        run: cargo generate --path /home/runner/work/esp-template/esp-template/github-esp-template --allow-commands --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d advanced=true -d wifi=false -d devcontainer=true -d wokwi=false -d alloc=false -d ci=false
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.board }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,9 @@ esp-backtrace = { version = "0.11.0", features = [
     "println",
 ] }
 esp-hal = { version = "0.16.0", features = [ "{{ mcu }}" ] }
-{% if logging -%}
-esp-println = { version = "0.9.0", features = ["{{ mcu }}", "log"] }
+esp-backtrace = { version = "0.10.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }
+esp-println = { version = "0.8.0", features = ["{{ mcu }}", "log"] }
 log = { version = "0.4.20" }
-{% else -%}
-esp-println = { version = "0.9.0", features = ["{{ mcu }}"] }
-{% endif -%}
 {% if alloc -%}
 esp-alloc = { version = "0.3.0" }
 {% endif -%}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ esp-backtrace = { version = "0.11.0", features = [
     "panic-handler",
     "println",
 ] }
-esp-hal = { version = "0.16.0", features = [ "{{ mcu }}" ] }
+esp-hal = { version = "0.17.0", features = [ "{{ mcu }}" ] }
 esp-println = { version = "0.9.0", features = ["{{ mcu }}", "log"] }
 log = { version = "0.4.20" }
 {% if alloc -%}
@@ -21,7 +21,7 @@ esp-alloc = { version = "0.3.0" }
 {% if wifi -%}
 embedded-svc = { version = "0.26.1", default-features = false, features = [] }
 embedded-io = "0.6.1"
-esp-wifi = { version = "0.4.0", features = [
+esp-wifi = { version = "0.5.0", features = [
     "{{ mcu }}",
     "phy-enable-usb",
     "utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ esp-wifi = { version = "0.4.0", features = [
     "{{ mcu }}",
     "phy-enable-usb",
     "utils",
-    "wifi-default",
+    "{{ esp_wifi_feature }}",
 ] }
 heapless = { version = "0.8.0", default-features = false }
 smoltcp = { version = "0.11.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ esp-backtrace = { version = "0.11.0", features = [
     "println",
 ] }
 esp-hal = { version = "0.16.0", features = [ "{{ mcu }}" ] }
-esp-backtrace = { version = "0.10.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }
-esp-println = { version = "0.8.0", features = ["{{ mcu }}", "log"] }
+esp-println = { version = "0.9.0", features = ["{{ mcu }}", "log"] }
 log = { version = "0.4.20" }
 {% if alloc -%}
 esp-alloc = { version = "0.3.0" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=-Tlinkall.x");
+    {% if wifi %}
+    println!("cargo:rustc-link-arg-bins=-Trom_functions.x");
+    {% endif -%}
+}

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -22,7 +22,7 @@ type = "bool"
 prompt = "Enable allocations via the esp-alloc crate?"
 default = false
 
-[conditional.'advanced && mcu != "esp32h2"'.placeholders.wifi]
+[conditional.'advanced'.placeholders.wifi]
 type    = "bool"
 prompt  = "Enable WiFi/Bluetooth/ESP-NOW via the esp-wifi crate?"
 default = false

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -42,11 +42,6 @@ type = "bool"
 prompt = "Add CI files for GitHub Action?"
 default = false
 
-[conditional.'advanced'.placeholders.logging]
-type = "bool"
-prompt = "Setup logging using the log crate?"
-default = false
-
 [conditional.'!devcontainer']
 ignore = [
     ".devcontainer/",

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,7 +1,14 @@
 if variable::get("wifi"){
-    print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/examples.md\n");
+    print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/esp-wifi/docs/examples.md\n");
 }
 
 if variable::get("ci") {
     file::rename(".github/rust_ci.yml", ".github/workflows/rust_ci.yml");
+}
+
+
+try {
+    system::command("cargo", ["fmt"]);
+} catch {
+    print("Failed to run rustfmt, please ensure rustfmt is installed and in your PATH variable.");
 }

--- a/post-script.rhai
+++ b/post-script.rhai
@@ -1,4 +1,4 @@
-if variable::get("mcu") != "esp32h2" && variable::get("wifi"){
+if variable::get("wifi"){
     print("\nFor more information and examples of esp-wifi showcasing Wifi,BLE and ESP-NOW, see https://github.com/esp-rs/esp-wifi/blob/main/examples.md\n");
 }
 

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -86,6 +86,7 @@ if !advanced {
 // Snippets - These should be short & self-contained, not depending on other snippets existing where possible.
 //
 
+// dependencies: none
 variable::set("alloc_snippet",
 `
 extern crate alloc;
@@ -104,6 +105,7 @@ fn init_heap() {
 }
 `);
 
+// depends on: `peripherals` being in scope
 variable::set("esp_wifi_snippet",
 `
 let timer = ${mcu}_hal::${meta.esp_wifi_timer};

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -110,7 +110,7 @@ let timer = ${mcu}_hal::${meta.esp_wifi_timer};
 let _init = esp_wifi::initialize(
     esp_wifi::EspWifiInitFor::${meta.esp_wifi_init},
     timer,
-    Rng::new(peripherals.RNG),
+    ${mcu}_hal::rng::Rng::new(peripherals.RNG),
     system.radio_clock_control,
     &clocks,
 )

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -54,7 +54,6 @@ let mcu = variable::get("mcu");
 let meta = metadata.get(mcu);
 
 variable::set("esp_wifi_feature", meta.get("esp_wifi_feature"));
-variable::set("hal_version", meta.get("hal_version"));
 variable::set("wokwi_board", meta.get("wokwi_board"));
 
 if mcu in ["esp32", "esp32s2", "esp32s3"] {
@@ -108,11 +107,11 @@ fn init_heap() {
 // depends on: `peripherals` being in scope
 variable::set("esp_wifi_snippet",
 `
-let timer = ${mcu}_hal::${meta.esp_wifi_timer};
+let timer = esp_hal::${meta.esp_wifi_timer};
 let _init = esp_wifi::initialize(
     esp_wifi::EspWifiInitFor::${meta.esp_wifi_init},
     timer,
-    ${mcu}_hal::rng::Rng::new(peripherals.RNG),
+    esp_hal::rng::Rng::new(peripherals.RNG),
     system.radio_clock_control,
     &clocks,
 )

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -2,36 +2,59 @@ let metadata = #{
     // Xtensa devices:
     esp32: #{
         wokwi_board: "board-esp32-devkit-c-v4",
+        esp_wifi_init: "Wifi",
+        esp_wifi_feature: "wifi",
+        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0"
     },
     esp32s2: #{
         wokwi_board: "board-esp32-s2-devkitm-1",
+        esp_wifi_init: "Wifi",
+        esp_wifi_feature: "wifi",
+        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0"
     },
     esp32s3: #{
         wokwi_board: "board-esp32-s3-devkitc-1",
+        esp_wifi_init: "Wifi",
+        esp_wifi_feature: "wifi",
+        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0"
     },
 
     // RISC-V devices:
      esp32c2: #{
         extensions: "imc",
         wokwi_board: "",
+        esp_wifi_init: "Wifi",
+        esp_wifi_feature: "wifi",
+        esp_wifi_timer: "systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0"
     },
     esp32c3: #{
         extensions: "imc",
         wokwi_board: "board-esp32-c3-devkitm-1",
+        esp_wifi_init: "Wifi",
+        esp_wifi_feature: "wifi",
+        esp_wifi_timer: "systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0"
     },
     esp32c6: #{
         extensions: "imac",
         wokwi_board: "board-esp32-c6-devkitc-1",
+        esp_wifi_init: "Wifi",
+        esp_wifi_feature: "wifi",
+        esp_wifi_timer: "systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0"
     },
     esp32h2: #{
         extensions: "imac",
         wokwi_board: "board-esp32-h2-devkitm-1",
+        esp_wifi_init: "Ble",
+        esp_wifi_feature: "ble",
+        esp_wifi_timer: "systimer::SystemTimer::new(peripherals.SYSTIMER).alarm0"
     },
 };
 
 let mcu = variable::get("mcu");
 let meta = metadata.get(mcu);
 
+variable::set("esp_wifi_feature", meta.get("esp_wifi_feature"));
+variable::set("hal_version", meta.get("hal_version"));
 variable::set("wokwi_board", meta.get("wokwi_board"));
 
 if mcu in ["esp32", "esp32s2", "esp32s3"] {
@@ -58,3 +81,39 @@ if !advanced {
     variable::set("wokwi", false);
     variable::set("wifi", false);
 }
+
+//
+// Snippets - These should be short & self-contained, not depending on other snippets existing where possible.
+//
+
+variable::set("alloc_snippet",
+`
+extern crate alloc;
+use core::mem::MaybeUninit;
+
+#[global_allocator]
+static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
+
+fn init_heap() {
+    const HEAP_SIZE: usize = 32 * 1024;
+    static mut HEAP: MaybeUninit<[u8; HEAP_SIZE]> = MaybeUninit::uninit();
+
+    unsafe {
+        ALLOCATOR.init(HEAP.as_mut_ptr() as *mut u8, HEAP_SIZE);
+    }
+}
+`);
+
+variable::set("esp_wifi_snippet",
+`
+let timer = ${mcu}_hal::${meta.esp_wifi_timer};
+let _init = esp_wifi::initialize(
+    esp_wifi::EspWifiInitFor::${meta.esp_wifi_init},
+    timer,
+    Rng::new(peripherals.RNG),
+    system.radio_clock_control,
+    &clocks,
+)
+.unwrap();
+`
+);

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -38,7 +38,6 @@ if mcu in ["esp32", "esp32s2", "esp32s3"] {
     // Xtensa devices:
     variable::set("arch", "xtensa");
     variable::set("gcc_target", `xtensa-${mcu}-elf`);
-    variable::set("has_swd", false);
     variable::set("rust_target", `xtensa-${mcu}-none-elf`);
     variable::set("toolchain", "esp");
 } else {
@@ -47,7 +46,6 @@ if mcu in ["esp32", "esp32s2", "esp32s3"] {
 
     variable::set("arch", "riscv");
     variable::set("gcc_target", "riscv32-esp-elf");
-    variable::set("has_swd", true);
     variable::set("rust_target", `riscv32${extensions}-unknown-none-elf`);
     variable::set("toolchain", "nightly");
 }

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -56,6 +56,5 @@ if !advanced {
     variable::set("ci", false);
     variable::set("devcontainer", false);
     variable::set("wokwi", false);
-    variable::set("logging", false);
     variable::set("wifi", false);
 }

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -4,19 +4,19 @@ let metadata = #{
         wokwi_board: "board-esp32-devkit-c-v4",
         esp_wifi_init: "Wifi",
         esp_wifi_feature: "wifi",
-        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0"
+        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0"
     },
     esp32s2: #{
         wokwi_board: "board-esp32-s2-devkitm-1",
         esp_wifi_init: "Wifi",
         esp_wifi_feature: "wifi",
-        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0"
+        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0"
     },
     esp32s3: #{
         wokwi_board: "board-esp32-s3-devkitc-1",
         esp_wifi_init: "Wifi",
         esp_wifi_feature: "wifi",
-        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks).timer0"
+        esp_wifi_timer: "timer::TimerGroup::new(peripherals.TIMG1, &clocks, None).timer0"
     },
 
     // RISC-V devices:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,67 +1,34 @@
 #![no_std]
 #![no_main]
 
-{% if alloc -%}
-extern crate alloc;
-use core::mem::MaybeUninit;
-{% endif -%}
 use esp_backtrace as _;
 use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay};
 use esp_println::println;
 
-{% if wifi -%}
-use esp_wifi::{initialize, EspWifiInitFor};
-
-{% if arch == "riscv" -%}
-use esp_hal::{systimer::SystemTimer, Rng};
-{% else -%}
-use esp_hal::{timer::TimerGroup, Rng};
-{% endif -%}
-{% endif -%}
-
 {% if alloc -%}
-#[global_allocator]
-static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();
-
-fn init_heap() {
-    const HEAP_SIZE: usize = 32 * 1024;
-    static mut HEAP: MaybeUninit<[u8; HEAP_SIZE]> = MaybeUninit::uninit();
-
-    unsafe {
-        ALLOCATOR.init(HEAP.as_mut_ptr() as *mut u8, HEAP_SIZE);
-    }
-}
+{{ alloc_snippet }}
 {% endif -%}
+
 #[entry]
 fn main() -> ! {
-    {%- if alloc %}
-    init_heap();
-    {%- endif %}
     let peripherals = Peripherals::take();
     let system = peripherals.SYSTEM.split();
 
     let clocks = ClockControl::max(system.clock_control).freeze();
     let mut delay = Delay::new(&clocks);
 
+    {%- if alloc %}
+    init_heap();
+    {%- endif %}
+
     esp_println::logger::init_logger_from_env();
-    log::info!("Hello world!");
+
     {% if wifi -%}
-    {% if arch == "riscv" -%}
-    let timer = SystemTimer::new(peripherals.SYSTIMER).alarm0;
-    {% else -%}
-    let timer = TimerGroup::new(peripherals.TIMG1, &clocks).timer0;
+    {{ esp_wifi_snippet }}
     {% endif -%}
-    let _init = initialize(
-        EspWifiInitFor::Wifi,
-        timer,
-        Rng::new(peripherals.RNG),
-        system.radio_clock_control,
-        &clocks,
-    )
-    .unwrap();
-    {% endif -%}
+
     loop {
-        println!("Loop...");
+        log::info!("Hello world!");
         delay.delay_ms(500u32);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@
 
 use esp_backtrace as _;
 use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay};
-use esp_println::println;
 
 {% if alloc -%}
 {{ alloc_snippet }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,15 +43,8 @@ fn main() -> ! {
     let clocks = ClockControl::max(system.clock_control).freeze();
     let mut delay = Delay::new(&clocks);
 
-    {% if logging -%}
-    // setup logger
-    // To change the log_level change the env section in .cargo/config.toml
-    // or remove it and set ESP_LOGLEVEL manually before running cargo run
-    // this requires a clean rebuild because of https://github.com/rust-lang/cargo/issues/10358
     esp_println::logger::init_logger_from_env();
-    log::info!("Logger is setup");
-    {% endif -%}
-    println!("Hello world!");
+    log::info!("Hello world!");
     {% if wifi -%}
     {% if arch == "riscv" -%}
     let timer = SystemTimer::new(peripherals.SYSTIMER).alarm0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay};
+use esp_hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, delay::Delay};
 
 {% if alloc -%}
 {{ alloc_snippet }}
@@ -14,7 +14,7 @@ fn main() -> ! {
     let system = peripherals.SYSTEM.split();
 
     let clocks = ClockControl::max(system.clock_control).freeze();
-    let mut delay = Delay::new(&clocks);
+    let delay = Delay::new(&clocks);
 
     {%- if alloc %}
     init_heap();
@@ -28,6 +28,6 @@ fn main() -> ! {
 
     loop {
         log::info!("Hello world!");
-        delay.delay_ms(500u32);
+        delay.delay(500.millis());
     }
 }


### PR DESCRIPTION
This PR:

* Removes the logging feature and enables it by default
* Enables esp-wifi to work with the esp32h2
* Simplifies the linker arg passing by using a build script.
* Moves some modular bits of code into snippets. Inspired by #140 

On its own this PR might seem a little pointless, but by having snippets we can easily make the generator less monolithic and easier to maintain. Instead of one template with a million options, we could now easily create more templates with less options which should reduce the cognitive load of making changes. I will do this in a follow up PR because it might be a bit controversial, but I think the changes here are okay on their own.