### PR TITLE
Minor fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "rust-analyzer.check.allTargets": false,
+    "rust-analyzer.check.allTargets": false,
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["{{ authors }}"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[profile.release]
+debug = true
+
 [dependencies]
 {{ mcu }}-hal = "{{ hal_version }}"
 esp-backtrace = { version = "0.10.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "print-uart"] }

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -64,8 +64,10 @@ ignore = [".vscode/launch.json", "diagram.json", "wokwi.toml"]
 
 [conditional.'!advanced']
 ignore = [
+    ".github",
+    ".vscode/launch.json",
+    ".vscode/tasks.json",
     ".devcontainer/",
-    ".vscode/",
     "docs/",
     "scripts/",
     ".github",


### PR DESCRIPTION
Apparently, the r-a setting was already fixed before ...

When not using advanced mode, I always got the `.github` folder but never got the VSCode settings file.

Additionally having debug symbols in release mode helps to decode addresses
