### PR TITLE
Add a debug and release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,6 @@ authors = ["{{ authors }}"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[profile.release]
-debug = true
-
 [dependencies]
 {{ mcu }}-hal = "{{ hal_version }}"
 esp-backtrace = { version = "0.11.0", features = ["{{ mcu }}", "panic-handler", "exception-handler", "println"] }
@@ -32,3 +29,17 @@ heapless = { version = "0.8.0", default-features = false }
 [features]
 default = ["{{ mcu }}-hal/xtal-40mhz"]
 {% endif %}
+
+[profile.dev]
+# Rust debug is too slow. 
+# For debug builds always builds with some optimization
+opt-level = "s"
+
+[profile.release]
+codegen-units = 1 # LLVM can perform better optimizations using a single thread
+debug = 2
+debug-assertions = false
+incremental = false
+lto = 'fat'
+opt-level = 's'
+overflow-checks = false


### PR DESCRIPTION
The rationale behind `opt-level = 's'` is that it's a good compromise between code size and code performance. On our chips, there is even a relationship between the two, as our caches are quite small so the smaller the code the more we can fit in the cache for better performance. Users can of course update this for their specific needs.