### PR TITLE
fix: file name not correct in wokwi.toml (#151)

### DIFF
--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,5 +1,5 @@
 [wokwi]
 version = 1
 gdbServerPort = 3333
-elf = "target/{{ rust_target }}/debug/{{ crate_name }}"
-firmware = "target/{{ rust_target }}/debug/{{ crate_name }}"
+elf = "target/{{ rust_target }}/debug/{{ project-name }}"
+firmware = "target/{{ rust_target }}/debug/{{ project-name }}"


### PR DESCRIPTION
Use `{{project-name}}` instead of `{{crate_name}}` in `wokwi.toml`.