### PR TITLE
fix: bump smoltcp crate version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ esp-wifi = { version = "0.4.0", features = [
     "wifi-default",
 ] }
 heapless = { version = "0.8.0", default-features = false }
-smoltcp = { version = "0.10.0", default-features = false, features = [
+smoltcp = { version = "0.11.0", default-features = false, features = [
     "medium-ethernet",
     "proto-dhcpv4",
     "proto-igmp",


### PR DESCRIPTION
When using with esp-wifi, it has some collisions with the versions.